### PR TITLE
Feat/add get server in transport

### DIFF
--- a/packages/cli/src/transports/CliTransport.ts
+++ b/packages/cli/src/transports/CliTransport.ts
@@ -1,6 +1,6 @@
 import { Interfaces } from '@ilos/core';
-import { CommandProvider } from '../providers/CommandProvider';
 
+import { CommandProvider } from '../providers/CommandProvider';
 
 /**
  * Cli Transport
@@ -15,12 +15,19 @@ export class CliTransport implements Interfaces.TransportInterface {
     this.kernel = kernel;
   }
 
-  getKernel():Interfaces.KernelInterface {
+  getServer(): void {
+    return;
+  }
+
+  getKernel(): Interfaces.KernelInterface {
     return this.kernel;
   }
 
   async up(opts: string[] = []) {
-    this.kernel.getContainer().get<CommandProvider>(CommandProvider).parse(opts);
+    this.kernel
+      .getContainer()
+      .get<CommandProvider>(CommandProvider)
+      .parse(opts);
   }
 
   async down() {

--- a/packages/cli/src/transports/CliTransport.ts
+++ b/packages/cli/src/transports/CliTransport.ts
@@ -15,7 +15,7 @@ export class CliTransport implements Interfaces.TransportInterface {
     this.kernel = kernel;
   }
 
-  getServer(): void {
+  getInstance(): void {
     return;
   }
 

--- a/packages/cli/src/types/BootstrapType.ts
+++ b/packages/cli/src/types/BootstrapType.ts
@@ -1,9 +1,9 @@
 import { Interfaces, Types } from '@ilos/core';
 
 export type BootstrapType = {
-  serviceProviders?: Types.NewableType<Interfaces.ServiceProviderInterface>[],
+  serviceProviders?: Types.NewableType<Interfaces.ServiceProviderInterface>[];
   transport?: {
-    [key: string]: (kernel: Interfaces.KernelInterface) => Interfaces.TransportInterface,
-  },
+    [key: string]: (kernel: Interfaces.KernelInterface) => Interfaces.TransportInterface;
+  };
   kernel?(): Interfaces.KernelInterface;
 };

--- a/packages/core/src/interfaces/TransportInterface.ts
+++ b/packages/core/src/interfaces/TransportInterface.ts
@@ -10,10 +10,10 @@ export interface TransportInterface {
 
   /**
    * Get Server instance such as httpServer, queue, etc.
-   * @returns {any | void}
+   * @returns {T | void}
    * @memberof TransportInterface
    */
-  getServer(): any | void;
+  getInstance<T>(): T | void;
 
   /**
    * Start the transport

--- a/packages/core/src/interfaces/TransportInterface.ts
+++ b/packages/core/src/interfaces/TransportInterface.ts
@@ -1,13 +1,19 @@
 import { KernelInterface } from './KernelInterface';
 
 export interface TransportInterface {
-
   /**
    * Get Kernel instance
    * @returns {KernelInterface}
    * @memberof TransportInterface
    */
-  getKernel():KernelInterface;
+  getKernel(): KernelInterface;
+
+  /**
+   * Get Server instance such as httpServer, queue, etc.
+   * @returns {any | void}
+   * @memberof TransportInterface
+   */
+  getServer(): any | void;
 
   /**
    * Start the transport
@@ -15,12 +21,12 @@ export interface TransportInterface {
    * @returns {Promise<void>}
    * @memberof TransportInterface
    */
-  up(opts?: string[]):Promise<void>;
+  up(opts?: string[]): Promise<void>;
 
   /**
    * Stop the transport
    * @returns {Promise<void>}
    * @memberof TransportInterface
    */
-  down():Promise<void>;
+  down(): Promise<void>;
 }

--- a/packages/framework/tests/http.spec.ts
+++ b/packages/framework/tests/http.spec.ts
@@ -1,38 +1,32 @@
 // tslint:disable max-classes-per-file
 import { expect } from 'chai';
 import axios from 'axios';
+
 import { HttpTransport } from '@ilos/transport-http';
 import { httpHandlerFactory } from '@ilos/handler-http';
 import { Container, Interfaces, Parents } from '@ilos/core';
+
 import { Kernel } from '../src/Kernel';
 
 import { ServiceProvider as MathServiceProvider } from './mock/MathService/ServiceProvider';
 import { ServiceProvider as ParentStringServiceProvider } from './mock/StringService/ServiceProvider';
 
 class StringServiceProvider extends Parents.ServiceProvider {
-  readonly serviceProviders = [
-    ParentStringServiceProvider,
-  ];
+  readonly serviceProviders = [ParentStringServiceProvider];
 
-  readonly handlers = [
-    httpHandlerFactory('math', 'http://127.0.0.1:8080'),
-  ];
+  readonly handlers = [httpHandlerFactory('math', 'http://127.0.0.1:8080')];
 }
 
 @Container.injectable()
 class MathKernel extends Kernel {
   name = 'math';
-  readonly serviceProviders = [
-    MathServiceProvider,
-  ];
+  readonly serviceProviders = [MathServiceProvider];
 }
 
 @Container.injectable()
 class StringKernel extends Kernel {
   name = 'string';
-  readonly serviceProviders = [
-    StringServiceProvider,
-  ];
+  readonly serviceProviders = [StringServiceProvider];
 }
 
 function makeRPCCall(port: number, req: { method: string; params?: any }[]) {
@@ -86,18 +80,14 @@ describe('Http only integration', () => {
   });
 
   it('should works', async () => {
-    const responseMath = await makeRPCCall(8080, [
-      { method: 'math:add', params: [1, 1] },
-    ]);
+    const responseMath = await makeRPCCall(8080, [{ method: 'math:add', params: [1, 1] }]);
     expect(responseMath.data).to.deep.equal({
       jsonrpc: '2.0',
       id: 0,
       result: 'math:2',
     });
 
-    const responseString = await makeRPCCall(8081, [
-      { method: 'string:hello', params: { name: 'sam' } },
-    ]);
+    const responseString = await makeRPCCall(8081, [{ method: 'string:hello', params: { name: 'sam' } }]);
     expect(responseString.data).to.deep.equal({
       jsonrpc: '2.0',
       id: 0,
@@ -106,9 +96,7 @@ describe('Http only integration', () => {
   });
 
   it('should works with internal service call', async () => {
-    const response = await makeRPCCall(8081, [
-      { method: 'string:result', params: { name: 'sam', add: [1, 1] } },
-    ]);
+    const response = await makeRPCCall(8081, [{ method: 'string:result', params: { name: 'sam', add: [1, 1] } }]);
 
     expect(response.data).to.deep.equal({
       jsonrpc: '2.0',

--- a/packages/transport-http/src/HttpTransport.spec.ts
+++ b/packages/transport-http/src/HttpTransport.spec.ts
@@ -17,6 +17,11 @@ describe('Http transport', () => {
         if ('method' in call) {
           switch (call.method) {
             case 'test':
+              // notifications return void
+              if (call.id === undefined || call.id === null) {
+                return;
+              }
+
               return {
                 id: 1,
                 jsonrpc: '2.0',
@@ -97,7 +102,7 @@ describe('Http transport', () => {
       .set('Accept', 'application/json')
       .set('Content-Type', 'application/json');
 
-    expect(response.status).to.equal(404);
+    expect(response.status).to.equal(405);
     expect(response.body).to.deep.equal({
       id: 1,
       jsonrpc: '2.0',
@@ -119,6 +124,9 @@ describe('Http transport', () => {
       .set('Accept', 'application/json')
       .set('Content-Type', 'application/json');
     expect(response.status).equal(200);
+    expect(response.body).to.have.property('id', 1);
+    expect(response.body).to.have.property('jsonrpc', '2.0');
+    expect(response.body).to.have.property('result');
   });
 
   it('notification request', async () => {
@@ -134,7 +142,7 @@ describe('Http transport', () => {
     expect(response.body).to.equal('');
   });
 
-  it('should fail if missing accept header', async () => {
+  it('should fail if missing Accept header', async () => {
     const response = await request
       .post('/')
       .send({
@@ -144,9 +152,13 @@ describe('Http transport', () => {
       })
       .set('Content-Type', 'application/json');
     expect(response.status).equal(415);
+    expect(response.body).to.have.property('id', 1);
+    expect(response.body).to.have.property('jsonrpc', '2.0');
+    expect(response.body).to.have.property('error');
   });
 
-  it('should fail if missing content type header', async () => {
+  // Content-type is infered from Accept header
+  it('should work without Content-type header', async () => {
     const response = await request
       .post('/')
       .send({
@@ -154,8 +166,11 @@ describe('Http transport', () => {
         jsonrpc: '2.0',
         method: 'test',
       })
-      .set('Content-Type', 'application/json');
-    expect(response.status).equal(415);
+      .set('Accept', 'application/json');
+    expect(response.status).equal(200);
+    expect(response.body).to.have.property('id', 1);
+    expect(response.body).to.have.property('jsonrpc', '2.0');
+    expect(response.body).to.have.property('result');
   });
 
   it('should fail if http verb is not POST', async () => {
@@ -169,6 +184,9 @@ describe('Http transport', () => {
       .set('Accept', 'application/json')
       .set('Content-Type', 'application/json');
     expect(response.status).equal(405);
+    expect(response.body).to.have.property('id', 1);
+    expect(response.body).to.have.property('jsonrpc', '2.0');
+    expect(response.body).to.have.property('error');
   });
 
   it('should fail if json is misformed', async () => {
@@ -178,6 +196,9 @@ describe('Http transport', () => {
       .set('Accept', 'application/json')
       .set('Content-Type', 'application/json');
     expect(response.status).equal(415);
+    expect(response.body).to.have.property('id', 1);
+    expect(response.body).to.have.property('jsonrpc', '2.0');
+    expect(response.body).to.have.property('error');
   });
 
   it('should fail if service reject', async () => {
@@ -191,6 +212,9 @@ describe('Http transport', () => {
       .set('Accept', 'application/json')
       .set('Content-Type', 'application/json');
     expect(response.status).equal(500);
+    expect(response.body).to.have.property('id', 1);
+    expect(response.body).to.have.property('jsonrpc', '2.0');
+    expect(response.body).to.have.property('error');
   });
 
   it('should fail if request is invalid', async () => {
@@ -204,6 +228,9 @@ describe('Http transport', () => {
       .set('Accept', 'application/json')
       .set('Content-Type', 'application/json');
     expect(response.status).equal(400);
+    expect(response.body).to.have.property('id', 1);
+    expect(response.body).to.have.property('jsonrpc', '2.0');
+    expect(response.body).to.have.property('error');
   });
 
   it('should fail if method is not found', async () => {
@@ -216,6 +243,9 @@ describe('Http transport', () => {
       })
       .set('Accept', 'application/json')
       .set('Content-Type', 'application/json');
-    expect(response.status).equal(404);
+    expect(response.status).equal(405);
+    expect(response.body).to.have.property('id', 1);
+    expect(response.body).to.have.property('jsonrpc', '2.0');
+    expect(response.body).to.have.property('error');
   });
 });

--- a/packages/transport-http/src/HttpTransport.spec.ts
+++ b/packages/transport-http/src/HttpTransport.spec.ts
@@ -60,7 +60,7 @@ describe('Http transport', () => {
 
     httpTransport.up();
 
-    request = supertest(httpTransport.server);
+    request = supertest(httpTransport.getServer());
   });
 
   after(() => {

--- a/packages/transport-http/src/HttpTransport.spec.ts
+++ b/packages/transport-http/src/HttpTransport.spec.ts
@@ -60,7 +60,7 @@ describe('Http transport', () => {
 
     httpTransport.up();
 
-    request = supertest(httpTransport.getServer());
+    request = supertest(httpTransport.getInstance());
   });
 
   after(() => {

--- a/packages/transport-http/src/HttpTransport.ts
+++ b/packages/transport-http/src/HttpTransport.ts
@@ -22,7 +22,7 @@ export class HttpTransport implements Interfaces.TransportInterface {
     return this.kernel;
   }
 
-  getServer(): http.Server {
+  getInstance(): http.Server {
     return this.server;
   }
 

--- a/packages/transport-http/src/HttpTransport.ts
+++ b/packages/transport-http/src/HttpTransport.ts
@@ -28,6 +28,8 @@ export class HttpTransport implements Interfaces.TransportInterface {
 
   async up(opts: string[] = []) {
     this.server = http.createServer((req, res) => {
+      res.setHeader('Content-type', 'application/json');
+
       if (
         !('content-type' in req.headers && 'accept' in req.headers) ||
         req.headers['content-type'] !== 'application/json' ||
@@ -55,7 +57,7 @@ export class HttpTransport implements Interfaces.TransportInterface {
             jsonrpc: '2.0',
             error: {
               code: -32601,
-              message: 'Method not found',
+              message: 'Method not allowed',
             },
           }),
         );
@@ -79,8 +81,7 @@ export class HttpTransport implements Interfaces.TransportInterface {
           this.kernel
             .handle(call)
             .then((results: Types.RPCResponseType) => {
-              res.setHeader('content-type', 'application/json');
-              res.statusCode = mapStatusCode(call, results);
+              res.statusCode = mapStatusCode(results);
               res.end(JSON.stringify(results));
             })
             .catch((e) => {

--- a/packages/transport-http/src/HttpTransport.ts
+++ b/packages/transport-http/src/HttpTransport.ts
@@ -34,27 +34,31 @@ export class HttpTransport implements Interfaces.TransportInterface {
         req.headers.accept !== 'application/json'
       ) {
         res.statusCode = 415;
-        res.end({
-          id: 1,
-          jsonrpc: '2.0',
-          error: {
-            code: -32000,
-            message: 'Wrong Content-type header. Requires application/json',
-          },
-        });
+        res.end(
+          JSON.stringify({
+            id: 1,
+            jsonrpc: '2.0',
+            error: {
+              code: -32000,
+              message: 'Wrong Content-type header. Requires application/json',
+            },
+          }),
+        );
       }
       // Add Host/Origin check
 
       if (req.method !== 'POST') {
         res.statusCode = 405;
-        res.end({
-          id: 1,
-          jsonrpc: '2.0',
-          error: {
-            code: -32601,
-            message: 'Method not found',
-          },
-        });
+        res.end(
+          JSON.stringify({
+            id: 1,
+            jsonrpc: '2.0',
+            error: {
+              code: -32601,
+              message: 'Method not found',
+            },
+          }),
+        );
       }
 
       let data = '';
@@ -77,29 +81,33 @@ export class HttpTransport implements Interfaces.TransportInterface {
             .then((results: Types.RPCResponseType) => {
               res.setHeader('content-type', 'application/json');
               res.statusCode = mapStatusCode(call, results);
-              res.end(results);
+              res.end(JSON.stringify(results));
             })
             .catch((e) => {
               res.statusCode = 500;
-              res.end({
-                id: 1,
-                jsonrpc: '2.0',
-                error: {
-                  code: -32000,
-                  message: e.message,
-                },
-              });
+              res.end(
+                JSON.stringify({
+                  id: 1,
+                  jsonrpc: '2.0',
+                  error: {
+                    code: -32000,
+                    message: e.message,
+                  },
+                }),
+              );
             });
         } catch (err) {
           res.statusCode = 415;
-          res.end({
-            id: 1,
-            jsonrpc: '2.0',
-            error: {
-              code: -32000,
-              message: 'Wrong content length',
-            },
-          });
+          res.end(
+            JSON.stringify({
+              id: 1,
+              jsonrpc: '2.0',
+              error: {
+                code: -32000,
+                message: 'Wrong content length',
+              },
+            }),
+          );
         }
       });
 

--- a/packages/transport-http/src/helpers/mapStatusCode.ts
+++ b/packages/transport-http/src/helpers/mapStatusCode.ts
@@ -1,7 +1,8 @@
 import { Types } from '@ilos/core';
 
 // https://www.jsonrpc.org/historical/json-rpc-over-http.html#response-codes
-export function mapStatusCode(call: Types.RPCCallType, results: Types.RPCResponseType): number {
+export function mapStatusCode(results: Types.RPCResponseType): number {
+  // Notifications have no results and must return a 204 No Content
   if (!results) {
     return 204;
   }
@@ -22,20 +23,41 @@ export function mapStatusCode(call: Types.RPCCallType, results: Types.RPCRespons
   const { error } = results;
   if (error) {
     switch (error.code) {
+      // Unauthorized
+      case -32501:
+        return 501;
+
+      // Forbidden
+      case -32503:
+        return 503;
+
+      // Conflict
+      case -32509:
+        return 409;
+
+      // Bad Request
       case -32600:
       case -32602:
         return 400;
-      case -32601:
+
+      // Not Found (ressource)
+      case -32504:
         return 404;
+
+      // Method Not found
+      case -32601:
+        return 405;
+
+      // Parse error --> Unprocessable entity
+      case -32700:
+        return 422;
+
+      // Server Error
       default:
         return 500;
     }
   }
 
-  // Notifications return a 204
-  if (!('id' in call) || call.id === '' || call.id === null) {
-    return 204;
-  }
-
+  // OK
   return 200;
 }

--- a/packages/transport-http/src/helpers/mapStatusCode.ts
+++ b/packages/transport-http/src/helpers/mapStatusCode.ts
@@ -1,7 +1,7 @@
 import { Types } from '@ilos/core';
 
 // https://www.jsonrpc.org/historical/json-rpc-over-http.html#response-codes
-export function mapStatus(call: Types.RPCCallType, results: Types.RPCResponseType): number {
+export function mapStatusCode(call: Types.RPCCallType, results: Types.RPCResponseType): number {
   if (!results) {
     return 204;
   }

--- a/packages/transport-http/src/helpers/mapsStatusCode.spec.ts
+++ b/packages/transport-http/src/helpers/mapsStatusCode.spec.ts
@@ -3,12 +3,12 @@
 import { describe } from 'mocha';
 import { expect } from 'chai';
 
-import { mapStatus } from './mapStatusCode';
+import { mapStatusCode } from './mapStatusCode';
 
 describe('RPC/HTTP status codes mapping', () => {
   it('regular -> 200', () => {
     expect(
-      mapStatus({ id: 1 } as any, {
+      mapStatusCode({ id: 1 } as any, {
         id: 1,
         jsonrpc: '2.0',
         result: {},
@@ -18,7 +18,7 @@ describe('RPC/HTTP status codes mapping', () => {
 
   it('notification -> 204', () => {
     expect(
-      mapStatus({} as any, {
+      mapStatusCode({} as any, {
         id: 1,
         jsonrpc: '2.0',
         result: {},
@@ -28,7 +28,7 @@ describe('RPC/HTTP status codes mapping', () => {
 
   it('Parse error -> 500', () => {
     expect(
-      mapStatus({ id: 1 } as any, {
+      mapStatusCode({ id: 1 } as any, {
         id: 1,
         jsonrpc: '2.0',
         error: { code: -32700, message: 'Parse error' },
@@ -38,7 +38,7 @@ describe('RPC/HTTP status codes mapping', () => {
 
   it('Invalid Request -> 400', () => {
     expect(
-      mapStatus({ id: 1 } as any, {
+      mapStatusCode({ id: 1 } as any, {
         id: 1,
         jsonrpc: '2.0',
         error: { code: -32600, message: 'Invalid Request' },
@@ -48,7 +48,7 @@ describe('RPC/HTTP status codes mapping', () => {
 
   it('Method not found -> 404', () => {
     expect(
-      mapStatus({ id: 1 } as any, {
+      mapStatusCode({ id: 1 } as any, {
         id: 1,
         jsonrpc: '2.0',
         error: { code: -32601, message: 'Method not found' },
@@ -58,7 +58,7 @@ describe('RPC/HTTP status codes mapping', () => {
 
   it('Invalid Params -> 400', () => {
     expect(
-      mapStatus({ id: 1 } as any, {
+      mapStatusCode({ id: 1 } as any, {
         id: 1,
         jsonrpc: '2.0',
         error: { code: -32602, message: 'Invalid Params' },
@@ -68,7 +68,7 @@ describe('RPC/HTTP status codes mapping', () => {
 
   it('Internal error -> 500', () => {
     expect(
-      mapStatus({ id: 1 } as any, {
+      mapStatusCode({ id: 1 } as any, {
         id: 1,
         jsonrpc: '2.0',
         error: { code: -32603, message: 'Internal error' },
@@ -78,7 +78,7 @@ describe('RPC/HTTP status codes mapping', () => {
 
   it('Server error 32000 -> 500', () => {
     expect(
-      mapStatus({ id: 1 } as any, {
+      mapStatusCode({ id: 1 } as any, {
         id: 1,
         jsonrpc: '2.0',
         error: { code: -32000, message: 'Server error' },
@@ -88,7 +88,7 @@ describe('RPC/HTTP status codes mapping', () => {
 
   it('Server error 32099 -> 500', () => {
     expect(
-      mapStatus({ id: 1 } as any, {
+      mapStatusCode({ id: 1 } as any, {
         id: 1,
         jsonrpc: '2.0',
         error: { code: -32000, message: 'Server error' },

--- a/packages/transport-http/src/helpers/mapsStatusCode.spec.ts
+++ b/packages/transport-http/src/helpers/mapsStatusCode.spec.ts
@@ -8,7 +8,7 @@ import { mapStatusCode } from './mapStatusCode';
 describe('RPC/HTTP status codes mapping', () => {
   it('regular -> 200', () => {
     expect(
-      mapStatusCode({ id: 1 } as any, {
+      mapStatusCode({
         id: 1,
         jsonrpc: '2.0',
         result: {},
@@ -17,28 +17,22 @@ describe('RPC/HTTP status codes mapping', () => {
   });
 
   it('notification -> 204', () => {
-    expect(
-      mapStatusCode({} as any, {
-        id: 1,
-        jsonrpc: '2.0',
-        result: {},
-      }),
-    ).to.eq(204);
+    expect(mapStatusCode()).to.eq(204);
   });
 
-  it('Parse error -> 500', () => {
+  it('Parse error -> 422', () => {
     expect(
-      mapStatusCode({ id: 1 } as any, {
+      mapStatusCode({
         id: 1,
         jsonrpc: '2.0',
         error: { code: -32700, message: 'Parse error' },
       }),
-    ).to.eq(500);
+    ).to.eq(422);
   });
 
   it('Invalid Request -> 400', () => {
     expect(
-      mapStatusCode({ id: 1 } as any, {
+      mapStatusCode({
         id: 1,
         jsonrpc: '2.0',
         error: { code: -32600, message: 'Invalid Request' },
@@ -46,19 +40,9 @@ describe('RPC/HTTP status codes mapping', () => {
     ).to.eq(400);
   });
 
-  it('Method not found -> 404', () => {
-    expect(
-      mapStatusCode({ id: 1 } as any, {
-        id: 1,
-        jsonrpc: '2.0',
-        error: { code: -32601, message: 'Method not found' },
-      }),
-    ).to.eq(404);
-  });
-
   it('Invalid Params -> 400', () => {
     expect(
-      mapStatusCode({ id: 1 } as any, {
+      mapStatusCode({
         id: 1,
         jsonrpc: '2.0',
         error: { code: -32602, message: 'Invalid Params' },
@@ -66,9 +50,19 @@ describe('RPC/HTTP status codes mapping', () => {
     ).to.eq(400);
   });
 
+  it('Method not found -> 405', () => {
+    expect(
+      mapStatusCode({
+        id: 1,
+        jsonrpc: '2.0',
+        error: { code: -32601, message: 'Method not found' },
+      }),
+    ).to.eq(405);
+  });
+
   it('Internal error -> 500', () => {
     expect(
-      mapStatusCode({ id: 1 } as any, {
+      mapStatusCode({
         id: 1,
         jsonrpc: '2.0',
         error: { code: -32603, message: 'Internal error' },
@@ -78,7 +72,7 @@ describe('RPC/HTTP status codes mapping', () => {
 
   it('Server error 32000 -> 500', () => {
     expect(
-      mapStatusCode({ id: 1 } as any, {
+      mapStatusCode({
         id: 1,
         jsonrpc: '2.0',
         error: { code: -32000, message: 'Server error' },
@@ -88,11 +82,41 @@ describe('RPC/HTTP status codes mapping', () => {
 
   it('Server error 32099 -> 500', () => {
     expect(
-      mapStatusCode({ id: 1 } as any, {
+      mapStatusCode({
         id: 1,
         jsonrpc: '2.0',
         error: { code: -32000, message: 'Server error' },
       }),
     ).to.eq(500);
+  });
+
+  it('Unauthorized -> 501', () => {
+    expect(
+      mapStatusCode({
+        id: 1,
+        jsonrpc: '2.0',
+        error: { code: -32501, message: 'Unauthorized' },
+      }),
+    ).to.eq(501);
+  });
+
+  it('Forbidden -> 503', () => {
+    expect(
+      mapStatusCode({
+        id: 1,
+        jsonrpc: '2.0',
+        error: { code: -32503, message: 'Forbidden' },
+      }),
+    ).to.eq(503);
+  });
+
+  it('Conflict -> 409', () => {
+    expect(
+      mapStatusCode({
+        id: 1,
+        jsonrpc: '2.0',
+        error: { code: -32509, message: 'Conflict' },
+      }),
+    ).to.eq(409);
   });
 });

--- a/packages/transport-redis/src/QueueTransport.ts
+++ b/packages/transport-redis/src/QueueTransport.ts
@@ -17,8 +17,12 @@ export class QueueTransport implements Interfaces.TransportInterface {
     this.kernel = kernel;
   }
 
-  getKernel():Interfaces.KernelInterface {
+  getKernel(): Interfaces.KernelInterface {
     return this.kernel;
+  }
+
+  getServer(): Queue[] {
+    return this.queues;
   }
 
   async up(opts: string[] = []) {
@@ -26,12 +30,14 @@ export class QueueTransport implements Interfaces.TransportInterface {
     // throw error
 
     const container = <Container.ContainerInterface>this.kernel.getContainer();
-    const services = Array.from(new Set(
-      container
-      .getHandlers()
-      .filter(cfg => ('local' in cfg && cfg.local) && ('queue' in cfg && !cfg.queue))
-      .map(cfg => cfg.service),
-      ));
+    const services = Array.from(
+      new Set(
+        container
+          .getHandlers()
+          .filter((cfg) => 'local' in cfg && cfg.local && ('queue' in cfg && !cfg.queue))
+          .map((cfg) => cfg.service),
+      ),
+    );
 
     for (const service of services) {
       const key = `${env}-${service}`;
@@ -42,17 +48,19 @@ export class QueueTransport implements Interfaces.TransportInterface {
       this.registerListeners(queue, key);
       this.queues.push(queue);
 
-      queue.process(job => this.kernel.handle({
-        jsonrpc: '2.0',
-        id: 1,
-        method: job.data.method,
-        params: {
-          params: job.data.params.params,
-          _context: {
-            ...job.data.params._context,
+      queue.process((job) =>
+        this.kernel.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: job.data.method,
+          params: {
+            params: job.data.params.params,
+            _context: {
+              ...job.data.params._context,
+            },
           },
-        },
-      }));
+        }),
+      );
     }
   }
 

--- a/packages/transport-redis/src/QueueTransport.ts
+++ b/packages/transport-redis/src/QueueTransport.ts
@@ -21,7 +21,7 @@ export class QueueTransport implements Interfaces.TransportInterface {
     return this.kernel;
   }
 
-  getServer(): Queue[] {
+  getInstance(): Queue[] {
     return this.queues;
   }
 


### PR DESCRIPTION
- Add a getServer() method to TransportInterface to get the underlying server. Either HTTP or Redis queues, etc...