### PR TITLE
remove no-use-before-declare deprecated tslint rule

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -40,7 +40,6 @@
     "no-trailing-whitespace": true,
     "no-unnecessary-initializer": true,
     "no-unused-expression": true,
-    "no-use-before-declare": true,
     "quotemark": [true, "single", "avoid-escape", "jsx-double"],
     "typedef-whitespace": [
       true,


### PR DESCRIPTION
Remove deprecated TSlint rule :

- `no-use-before-declare`

Error message
```
no-use-before-declare is deprecated. Since TypeScript 2.9. Please use the built-in compiler checks instead.
```

Documentation : https://palantir.github.io/tslint/rules/no-use-before-declare/
