### PR TITLE
remove try/catch to bubble errors

### DIFF
--- a/packages/config/src/ConfigExtension.ts
+++ b/packages/config/src/ConfigExtension.ts
@@ -1,16 +1,13 @@
 import { Interfaces } from '@ilos/core';
 import { EnvInterfaceResolver, Env } from '@ilos/env';
+
 import { ConfigInterfaceResolver } from './ConfigInterfaces';
 import { Config } from './Config';
 
 export class ConfigExtension implements Interfaces.RegisterHookInterface, Interfaces.InitHookInterface {
   static readonly key: string = 'config';
 
-  constructor(
-    protected readonly params: string | { workingPath: string, configDir: string } | { [k: string]: any }
-  ) {
-    //
-  }
+  constructor(protected readonly params: string | { workingPath: string; configDir: string } | { [k: string]: any }) {}
 
   async register(serviceContainer: Interfaces.ServiceContainerInterface) {
     const container = serviceContainer.getContainer();
@@ -24,27 +21,19 @@ export class ConfigExtension implements Interfaces.RegisterHookInterface, Interf
 
     serviceContainer.registerHooks(Config.prototype, ConfigInterfaceResolver);
   }
-  
+
   async init(serviceContainer: Interfaces.ServiceContainerInterface) {
     const container = serviceContainer.getContainer();
     const config = container.get(ConfigInterfaceResolver);
-    // TODO: throw error if config not found ?
+
     if (typeof this.params === 'string') {
-      try {
-        config.loadConfigDirectory(this.params);
-      } catch {
-        // Do nothing
-      }
-    } else if (!!this.params.workingPath && !!this.params.configDir) {
-      try {
-        config.loadConfigDirectory(this.params.workingPath, this.params.configDir);
-      } catch {
-        // Do nothing
-      }
+      config.loadConfigDirectory(this.params);
+    } else if (this.params.workingPath && this.params.configDir) {
+      config.loadConfigDirectory(this.params.workingPath, this.params.configDir);
     } else {
       Reflect.ownKeys(this.params).forEach((k: string) => {
         config.set(k, this.params[k]);
-      })
+      });
     }
   }
 }


### PR DESCRIPTION
Issue #11 
Removed `try/catch` blocks around config loading to let the errors bubble up.
The errors linked to not found config directories are skipped to focus on configuration variables' errors.

e.g. a missing ENV_VAR without a default will throw an explicite message.
```ts
# config/my-config.ts
export const myVar = env('APP_MY_VAR');
```

If the `APP_MY_VAR` isn't set :
```shell
Error: Unknown env key APP_MY_VAR
```