### PR TITLE
let user pass 0 as server port for auto mode

### DIFF
--- a/packages/transport-http/src/HttpTransport.ts
+++ b/packages/transport-http/src/HttpTransport.ts
@@ -117,8 +117,10 @@ export class HttpTransport implements TransportInterface {
         res.end();
       });
     });
-    const [optsPort] = opts;
-    const port = optsPort ? Number(optsPort) : 8080;
+
+    // Passing 0 as port lets the net stack use a random free port
+    const optsPort = parseInt(opts[0], 10);
+    const port = optsPort || optsPort === 0 ? optsPort : 8080;
 
     this.server.listen(port);
   }


### PR DESCRIPTION
Change the check on the port option to let the user pass `0`.
The Nodejs _net_ package handling the server will search for the next available port to start the _listen()_